### PR TITLE
Add community extension: Catalogs Endpoint

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -2,6 +2,7 @@
 COMMUNITY_REPOS = [
   # org, repo name
   ['cedadev', 'stac-context-collections'], 
+  ['Healy-Hyperspatial', 'stac-api-extensions-catalogs'],
 ]
 
 # Other extensions that are not on GitHub

--- a/python/config.py
+++ b/python/config.py
@@ -2,7 +2,7 @@
 COMMUNITY_REPOS = [
   # org, repo name
   ['cedadev', 'stac-context-collections'], 
-  ['Healy-Hyperspatial', 'virtual-catalogs-endpoint'],
+  ['Healy-Hyperspatial', 'multi-tenant-catalogs'],
   ['Healy-Hyperspatial', 'collection-search-large-payloads'],
   ['Healy-Hyperspatial', 'skos-registry'], 
 ]


### PR DESCRIPTION
Adds a new community extension for the Catalogs Endpoint.

**Repository:** https://github.com/Healy-Hyperspatial/stac-api-extensions-catalogs-endpoint

This extension introduces a `/catalogs` endpoint to enable a Virtual Organizational architecture. It serves as a registry for logical sub-catalogs, allowing users to organize data into flexible hierarchies (e.g., by theme, project, or SKOS concepts) without duplicating the underlying data.

Key Capabilities:

Virtual Organization: Create logical groupings ("playlists") of collections based on semantics or themes.

Poly-hierarchy: Supports collections belonging to multiple catalogs simultaneously.

Safety-First Transactions: Defines transactional endpoints to create, update, and delete catalog structures. Crucially, these operations manage links, not data. Deleting a catalog via this endpoint strictly unlinks the contained collections, ensuring that the actual data (Collections/Items) is never accidentally destroyed.

We are currently looking at implementing this specification in the `stac-fastapi-elasticsearch-opensearch` project and are listing it here to allow for open-source collaboration.

**Context / Related Issues:**
This extension addresses the need for multi-catalog aggregation discussed in the following issues:
* stac-utils/stac-fastapi-elasticsearch-opensearch#520
* stac-utils/stac-fastapi-elasticsearch-opensearch#308